### PR TITLE
Fix to the relationship setting code example in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ using the 18 digit Salesforce id, but maintain our ActiveRecord relationships.
 		end
 
 		def salesforce_account_id=(account_id)
-		  self.account = nil and return if account_id.nil?
+		  self.account = nil if account_id.nil? and return
 		  self.account = Account.find_or_create_by_salesforce_id(account_id)
 		end
 	end


### PR DESCRIPTION
Since the left side of the 'and' will return nil, the 'return' will not be evaluated. This results in the code moving on to the next line, and setting the relationship to either a new or existing record with a salesforce id of nil.
