### PR TITLE
Convert arrays to semi-colon seperated values

### DIFF
--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -221,7 +221,9 @@ module SalesforceArSync
 
     private
 
-    # Multi-picklists in the SF Rest API
+    # Multi-picklists in the SF Rest API are expected to be in a semicolon separated list
+    # This method converts all attribute that are arrays into these values
+    # Eg. ["A","B","C"]  =>  "A;B;C"
     def format_attributes(attributes)
       attributes.each do |k,v|
         attributes[k] = v.join(";") if v.is_a?(Array)


### PR DESCRIPTION
When syncing values in multi-select picklists SF expects them in a semicolon separated list.  Until now we have been converting the attributes to JSON which will send them as an array.  To fix this we will use a helper method to convert all arrays into semicolon separated values before converting them to JSON.
