### PR TITLE
require rexml for ruby 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,5 @@
 * WebID syncing fixed
 # Version 4.0.0
 * Changed Databasedotcom over to Restforce
+# Version 4.1.0
+* Add rexml dependency to support Ruby 3.0

--- a/lib/salesforce_ar_sync/version.rb
+++ b/lib/salesforce_ar_sync/version.rb
@@ -1,3 +1,3 @@
 module SalesforceArSync
-  VERSION = '4.0.0'
+  VERSION = '4.1.0'
 end

--- a/salesforce_ar_sync.gemspec
+++ b/salesforce_ar_sync.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack-xml_parser'
   gem.add_dependency 'rails', '>= 5'
+  gem.add_dependency 'rexml', '~> 3.2'
 
   gem.add_development_dependency 'ammeter', '~> 1.1.2'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Require rexml as a dependency because Ruby 3 moved rexml from a default gem to a bundled gem.  rexml is used when rendering xml.

https://stdgems.org/rexml/

