### PR TITLE
MCWEB-2374: Manual Parameter Syncing

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,42 @@
+name: Ruby Gem
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+  build:
+    if: ${{ github.event.base_ref == 'refs/heads/master' }}
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Echo GitHub Event Ref
+      run: echo "${{ github.event.base_ref }}"
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.6
+    - name: Publish to GPR
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+        OWNER: ${{ github.repository_owner }}
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,11 @@
-appraise "rails-4.0" do
-  gem "rails", "4.0.4"
+appraise 'rails-7.1' do
+  gem 'rails', '~> 7.1.0'
 end
 
-appraise "rails-4.1" do
-  gem "rails", "4.1.1"
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
 end
 
-appraise "rails-4.2" do
-  gem "rails", "4.2.1"
+appraise 'rails-8.0' do
+  gem 'rails', '~> 8.0.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,5 +43,5 @@
 # Version 5.1.0
 * Updated Psych Processing
 
-# Version 5.1.0
+# Version 5.2.0
 * Added the ability to manually trigger syncing of specific model attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,47 @@
 # Version 1.1.0
 * Salesforce objects you wish to sync no longer need to be materialized
 * Requires that `SF_CLIENT` be initialized in your databasedotcom configuration
+
 # Version 1.1.1
 * Adds missed paths to the gemspec to fix initialization issues when used as a gem
+
 # Version 1.1.2
 * Adds support for namespaced Salesforce apps
+
 # Version 1.1.3
 * Adds support for outbound deletions
 * Adds ability to configure inbound/outbound deletions on a per model basis
+
 # Version 1.1.4
 * Fix issue with multi-select picklists introduced when using REST API
+
 # Version 2.0.0
 * Add active record web id field
 * Moved from Rails 3 to Rails 4
+
 # Version 2.0.1
 * Add the ability to map delete messages to any model without modifying the outbound message in Salesforce
+
 # Version 2.0.2
 * Updated IP address ranges for Salesforce.
+
 # Version 3.2.0
 * Adds support for Rails 5
 * Added ability to specify readonly fields for salesforce syncable models so those fields don't try to sync back to Salesforce
 * WebID syncing fixed
+
 # Version 4.0.0
 * Changed Databasedotcom over to Restforce
+
 # Version 4.1.0
 * Add rexml dependency to support Ruby 3.0
+
 # Version 5.0.0
 * Replace .delay calls with ActiveJobs
 * Add job_queue config
+
 # Version 5.1.0
 * Updated Psych Processing
+
+# Version 5.1.0
+* Added the ability to manually trigger syncing of specific model attributes.

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "appraisal"
+gem 'appraisal'
+gem 'debug'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,56 @@
 SalesforceARSync allows you to sync models and fields with Salesforce through a combination of
 Outbound Messaging, SOAP and restforce.
 
+### Contents
+
+- [Installation](#installation)
+  - [Requirements](#requirements)
+  - [Salesforce Setup](#salesforce-setup)
+    - [1. Setup Remote Access](#1-setup-remote-access)
+    - [2. Setup Outbound Messaging](#2-setup-outbound-messaging)
+  - [restforce](#restforce)
+  - [Gem Installation](#gem-installation)
+  - [Application Setup](#application-setup)
+- [Usage](#usage)
+  - [Configuration Options](#configuration-options)
+  - [Model Options](#model-options)
+    - [salesforce\_sync\_enabled](#salesforce_sync_enabled)
+    - [sync\_attributes](#sync_attributes)
+    - [async\_attributes](#async_attributes)
+    - [default\_attributes\_for\_create](#default_attributes_for_create)
+    - [salesforce\_id\_attribute\_name](#salesforce_id_attribute_name)
+    - [web\_id\_attribute\_name](#web_id_attribute_name)
+    - [activerecord\_web\_id\_attribute\_name](#activerecord_web_id_attribute_name)
+    - [salesforce\_sync\_web\_id](#salesforce_sync_web_id)
+    - [additional\_lookup\_fields](#additional_lookup_fields)
+    - [web\_class\_name](#web_class_name)
+    - [salesforce\_object\_name](#salesforce_object_name)
+    - [except](#except)
+    - [save\_method](#save_method)
+    - [unscoped\_updates](#unscoped_updates)
+    - [readonly\_fields](#readonly_fields)
+  - [Stopping the Sync](#stopping-the-sync)
+  - [Manual Sync](#manual-sync)
+- [Examples](#examples)
+  - [Our Basic Example Model](#our-basic-example-model)
+  - [Making the Model Syncable](#making-the-model-syncable)
+  - [Stopping the Model from Syncing with a Flag](#stopping-the-model-from-syncing-with-a-flag)
+  - [Stopping the Model from Syncing with a Method](#stopping-the-model-from-syncing-with-a-method)
+  - [Stopping a Record from Syncing](#stopping-a-record-from-syncing)
+  - [Specify Async Attributes](#specify-async-attributes)
+  - [Specify Default Attributes when an Object is Created](#specify-default-attributes-when-an-object-is-created)
+  - [Relationships](#relationships)
+  - [Defining a Custom Salesforce Object](#defining-a-custom-salesforce-object)
+- [Deletes](#deletes)
+  - [Inbound Deletes](#inbound-deletes)
+  - [Outbound Deletes](#outbound-deletes)
+  - [Soft Deletes](#soft-deletes)
+- [Errors](#errors)
+  - [Outbound Message Errors](#outbound-message-errors)
+- [Finding your 18 Character Organization ID](#finding-your-18-character-organization-id)
+- [Testing](#testing)
+- [Contributing](#contributing)
+
 ## Installation
 
 ### Requirements
@@ -144,35 +194,6 @@ An example of adding an aliased object to the deletion map should look like the 
       Account: 'YourModelName'
 
 ### Model Options
-The model can have several options set:
-
-[__salesforce_sync_enabled__](#salesforce_sync_enabled)
-
-[__sync_attributes__](#sync_attributes)
-
-[__async_attributes__](#async_attributes)
-
-[__default_attributes_for_create__](#default_attributes_for_create)
-
-[__salesforce_id_attribute_name__](#salesforce_id_attribute_name)
-
-[__web_id_attribute_name__](#web_id_attribute_name)
-
-[__activerecord_web_id_attribute_name__](#activerecord_web_id_attribute_name)
-
-[__salesforce_sync_web_id__](#salesforce_sync_web_id)
-
-[__web_class_name__](#web_class_name)
-
-[__salesforce_object_name__](#salesforce_object_name)
-
-[__except__](#except)
-
-[__save_method__](#save_method)
-
-[__unscoped_updates__](#unscoped_updates)
-
-[__readonly_fields__](#readonly_fields)
 
 #### <a id="salesforce_sync_enabled"></a>salesforce_sync_enabled
 Model level option to enable disable the sync, defaults to true.
@@ -285,7 +306,7 @@ unscoped_updates: true
 ````
 
 #### readonly_fields
-Optionally set fields on the salesforce object that have been defined as Read Only in Salesforce. 
+Optionally set fields on the salesforce object that have been defined as Read Only in Salesforce.
 This helps to ensure that those fields are not synced from the model to salesforce (but still syncable the other way).
 Accepts the salesforce field, not the model's fields.
 
@@ -301,6 +322,16 @@ Stopping the gem from syncing can be done on three levels.
 configuration variable _SALESFORCE_AR_SYNC_CONFIG["SYNC_ENABLED"]_
 * The model level by setting the _:salesforce_sync_enabled => false_ or _:except => :method_name_
 * The instance level by setting _:salesforce_skip_sync => true_ in the instance
+
+### Manual Sync
+
+You can trigger a manual sync of any configured attributes. All checks to skip syncing or to sync asynchronously will still be executed.
+
+```ruby
+my_user_record.salesforce_sync(:email)
+
+my_user_record.salesforce_sync(:email, :phone)
+```
 
 ## Examples
 
@@ -499,6 +530,11 @@ If the SOAP handler encounters an error it will be recorded in the log of the ou
  Your 15 character organization id can be found in _Setup -> Company Profile -> Company Information_. You must convert
  it to an 18 character id by running it through the tool located here:
  http://cloudjedi.wordpress.com/no-fuss-salesforce-id-converter/ or by installing the Force.com Utility Belt for Chrome.
+
+## Testing
+This gem uses [Appraisal](https://github.com/thoughtbot/appraisal) to test against many versions of Rails.
+
+Run the test script to automatically set up and run the test suite: `./test`
 
 ## Contributing
 

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "4.0.4"
+gem "debug"
+gem "rails", "~> 7.1.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "4.1.1"
+gem "debug"
+gem "rails", "~> 7.2.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "rails", "4.2.1"
-gem 'mime-types', '2.6.2'
+gem "debug"
+gem "rails", "~> 8.0.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -214,7 +214,7 @@ module SalesforceArSync
     def salesforce_sync(*attrs)
       return if salesforce_skip_sync?
 
-      attributes_to_update = salesforce_attributes_to_update(false, attrs)
+      attributes_to_update = salesforce_attributes_to_update(attrs.any?, attrs)
 
       if salesforce_perform_async_call?
         SalesforceArSync::SalesforceObjectSyncJob.set(priority: 50).perform_later(

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -205,9 +205,9 @@ module SalesforceArSync
 
     # if attributes specified in the async_attributes array are the only attributes being modified, then sync the data
     # via delayed_job
-    def salesforce_perform_async_call?
-      return false if salesforce_attributes_to_update.empty? || self.class.salesforce_async_attributes.empty?
-      salesforce_attributes_to_update.keys.all? { |key| self.class.salesforce_async_attributes.include?(key) } && salesforce_id.present?
+    def salesforce_perform_async_call?(attributes_to_update)
+      return false if attributes_to_update.empty? || self.class.salesforce_async_attributes.empty?
+      attributes_to_update.keys.all? { |key| self.class.salesforce_async_attributes.include?(key) } && salesforce_id.present?
     end
 
     # sync model data to Salesforce, adding any Salesforce validation errors to the models errors
@@ -216,7 +216,7 @@ module SalesforceArSync
 
       attributes_to_update = salesforce_attributes_to_update(attrs.any?, attrs)
 
-      if salesforce_perform_async_call?
+      if salesforce_perform_async_call?(attributes_to_update)
         SalesforceArSync::SalesforceObjectSyncJob.set(priority: 50).perform_later(
           self.class.salesforce_web_class_name, salesforce_id,
           attributes_to_update.to_json

--- a/lib/salesforce_ar_sync/version.rb
+++ b/lib/salesforce_ar_sync/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SalesforceArSync
-  VERSION = '5.1.1'
+  VERSION = '5.2.0'
 end

--- a/lib/salesforce_ar_sync/version.rb
+++ b/lib/salesforce_ar_sync/version.rb
@@ -1,3 +1,3 @@
 module SalesforceArSync
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end

--- a/salesforce_ar_sync.gemspec
+++ b/salesforce_ar_sync.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'ammeter', '~> 1.1.2'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'sqlite3', '~> 1.4'
+  gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'vcr'
   gem.add_development_dependency 'webmock'
 

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -1,3 +1,0 @@
-sqlite3mem:
-  :adapter: sqlite3
-  :database: ":memory:"

--- a/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
+++ b/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
@@ -535,8 +535,8 @@ describe SalesforceArSync, :vcr do
   end
 
   describe '#salesforce_sync' do
-    let(:contact) do
-      Contact.new(
+    let!(:contact) do
+      Contact.create(
         first_name: 'Jane',
         last_name: 'Doe',
         email: 'jdoe@example.com',

--- a/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
+++ b/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
@@ -534,6 +534,45 @@ describe SalesforceArSync, :vcr do
     end
   end
 
+  describe '#salesforce_sync' do
+    let(:contact) do
+      Contact.new(
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: 'jdoe@example.com',
+        salesforce_id: '001xx000003DGg3AAG'
+      )
+    end
+    let(:restforce_client_stub) { OpenStruct.new }
+
+    before do
+      SalesforceArSync.config['SYNC_ENABLED'] = true
+      stub_const('SF_CLIENT', restforce_client_stub)
+
+      allow(SF_CLIENT).to receive(:update)
+      allow(contact).to receive(:salesforce_object_exists?).and_return(true)
+    end
+
+    context 'when supplied with which attributes to sync' do
+      it 'calls SF_CLIENT.update with the correct parameters' do
+        contact.salesforce_sync(:first_name, :email_address)
+        expect(SF_CLIENT).to have_received(:update).with(
+          'Contact',
+          Id: contact.salesforce_id,
+          Contact.salesforce_sync_attribute_mapping.invert[:first_name] => contact.first_name,
+          Contact.salesforce_sync_attribute_mapping.invert[:email_address] => contact.email_address
+        )
+      end
+    end
+
+    context 'when supplied with invalid attributes to sync' do
+      it 'calls SF_CLIENT.update with the correct parameters' do
+        contact.salesforce_sync(:bad_attribute)
+        expect(SF_CLIENT).not_to have_received(:update)
+      end
+    end
+  end
+
   describe '#get_activerecord_web_id' do
     context 'no custom web id' do
       it 'returns the id' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'debug'
 require 'rails/all'
 require 'salesforce_ar_sync'
 require 'active_record'
@@ -9,14 +10,11 @@ require 'vcr'
 
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
-ENGINE_RAILS_ROOT=File.join(File.dirname(__FILE__), '../')
-plugin_test_dir = File.dirname(__FILE__)
+ENGINE_RAILS_ROOT = File.join(__dir__, '../')
 
-# Load sqlite3 mem database for testing
-ActiveRecord::Base.configurations = YAML::load_file(File.join(plugin_test_dir, "db", "database.yml"))
-ActiveRecord::Base.establish_connection((ENV["DB"] || "sqlite3mem").to_sym)
-ActiveRecord::Migration.verbose = false
-load(File.join(plugin_test_dir, "db", "schema.rb"))
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Schema.verbose = false
+load(File.join(__dir__, "db", "schema.rb"))
 
 VCR.configure do |c|
   c.cassette_library_dir =  "vcr_cassettes"

--- a/test
+++ b/test
@@ -1,0 +1,3 @@
+bundle install
+bundle exec appraisal install
+bundle exec appraisal rake


### PR DESCRIPTION
### Changes
1. Added the option to manually sync attributes.
2. Updated test suite.
    - Fixed database connection issues with SQLite in memory.
    - Updated the Appraisal configuration.
    - Added a helper script to build and test.
4. Updated documentation.
5. Added the debug gem for local development.
6. Added Gem push automation.