### PR TITLE
MCWEB-2374: Manual Parameter Object Creation Bugfix

### DIFF
--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -1,0 +1,32 @@
+# Only test Ruby maintenance branches.
+# https://www.ruby-lang.org/en/downloads/branches
+name: Gem Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  tests_matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    strategy:
+      matrix:
+        ruby:
+          - "3.2"
+          - "3.3"
+          - "3.4"
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run Test Suite
+      run: ./test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@
 
 # Version 5.2.1
 * Reverted accidental change to object creation during sync.
+* Added CI for the test suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,6 @@
 
 # Version 5.2.0
 * Added the ability to manually trigger syncing of specific model attributes.
+
+# Version 5.2.1
+* Reverted accidental change to object creation during sync.

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem 'appraisal'
 gem 'debug'
+gem 'ostruct'

--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ configuration variable _SALESFORCE_AR_SYNC_CONFIG["SYNC_ENABLED"]_
 
 You can trigger a manual sync of any configured attributes. All checks to skip syncing or to sync asynchronously will still be executed.
 
+If the record does not exist in Salesforce, the provided attributes will be ignored and all attributes will be synced.
+
 ```ruby
 my_user_record.salesforce_sync(:email)
 

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "debug"
+gem "ostruct"
 gem "rails", "~> 7.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "debug"
+gem "ostruct"
 gem "rails", "~> 7.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "debug"
+gem "ostruct"
 gem "rails", "~> 8.0.0"
 
 gemspec path: "../"

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -224,8 +224,8 @@ module SalesforceArSync
       else
         if salesforce_object_exists?
           salesforce_update_object(attributes_to_update) if attributes_to_update.present?
-        else
-          salesforce_create_object(attributes_to_update(!new_record?)) if salesforce_id.nil?
+        elsif salesforce_id.nil?
+          salesforce_create_object(salesforce_attributes_to_update(!new_record?))
         end
       end
     rescue Exception => ex

--- a/lib/salesforce_ar_sync/version.rb
+++ b/lib/salesforce_ar_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalesforceArSync
-  VERSION = '5.2.0'
+  VERSION = '5.2.1'
 end

--- a/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
+++ b/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper.rb'
+require 'spec_helper'
 
 # for testing our environment variables
 SalesforceArSync.config = {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'debug'
+require 'ostruct'
 require 'rails/all'
 require 'salesforce_ar_sync'
 require 'active_record'


### PR DESCRIPTION
- Reverted accidental change to object creation during sync.
- Added CI for the test suite.
- Added ostruct to test suite manually as it is being deprecated from the default gems in later versions of Ruby.