### PR TITLE
MEM-7622: Stop-salesforce-syncable-objects-from-being-saved-with-sale…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,6 @@
 # Version 5.2.1
 * Reverted accidental change to object creation during sync.
 * Added CI for the test suite.
+
+# Version 5.3.0
+* Changed salesforce_ar_sync to use bang (!) versions of Restforce CRUD methods to raise errors on Salesforce save failures instead of returning false.

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -177,6 +177,7 @@ module SalesforceArSync
     def salesforce_create_object(attributes)
       attributes[self.class.salesforce_web_id_attribute_name.to_s] = id if self.class.salesforce_sync_web_id? && !new_record?
       salesforce_id = SF_CLIENT.create!(salesforce_object_name, format_attributes(attributes))
+      @exists_in_salesforce = true
     end
 
     def salesforce_update_object(attributes)

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -176,7 +176,7 @@ module SalesforceArSync
 
     def salesforce_create_object(attributes)
       attributes[self.class.salesforce_web_id_attribute_name.to_s] = id if self.class.salesforce_sync_web_id? && !new_record?
-      salesforce_id = SF_CLIENT.create!(salesforce_object_name, format_attributes(attributes))
+      self.salesforce_id = SF_CLIENT.create!(salesforce_object_name, format_attributes(attributes))
       @exists_in_salesforce = true
     end
 

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -176,20 +176,24 @@ module SalesforceArSync
 
     def salesforce_create_object(attributes)
       attributes[self.class.salesforce_web_id_attribute_name.to_s] = id if self.class.salesforce_sync_web_id? && !new_record?
-      salesforce_id = SF_CLIENT.create(salesforce_object_name, format_attributes(attributes))
-      self.salesforce_id = salesforce_id
-      @exists_in_salesforce = true
+      salesforce_id = SF_CLIENT.create!(salesforce_object_name, format_attributes(attributes))
+      if salesforce_id.present? && salesforce_id != 0
+        self.salesforce_id = salesforce_id
+        @exists_in_salesforce = true
+      else
+        raise "Salesforce returned invalid ID: #{salesforce_id}"
+      end
     end
 
     def salesforce_update_object(attributes)
       attributes[self.class.salesforce_web_id_attribute_name.to_s] = id if self.class.salesforce_sync_web_id? && !new_record?
 
-      SF_CLIENT.update(salesforce_object_name, format_attributes(attributes).merge(Id: salesforce_id))
+      SF_CLIENT.update!(salesforce_object_name, format_attributes(attributes).merge(Id: salesforce_id))
     end
 
     def salesforce_delete_object
       if ar_sync_outbound_delete?
-        SF_CLIENT.destroy(salesforce_object_name, salesforce_id)
+        SF_CLIENT.destroy!(salesforce_object_name, salesforce_id)
       end
     end
 
@@ -236,7 +240,7 @@ module SalesforceArSync
     def sync_web_id
       return false if !self.class.salesforce_sync_web_id? || SalesforceArSync.config['SYNC_ENABLED'] == false
 
-      SF_CLIENT.update(salesforce_object_name, Id: salesforce_id, self.class.salesforce_web_id_attribute_name.to_s => get_activerecord_web_id) if salesforce_id
+      SF_CLIENT.update!(salesforce_object_name, Id: salesforce_id, self.class.salesforce_web_id_attribute_name.to_s => get_activerecord_web_id) if salesforce_id
     end
 
     def get_activerecord_web_id

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -177,12 +177,6 @@ module SalesforceArSync
     def salesforce_create_object(attributes)
       attributes[self.class.salesforce_web_id_attribute_name.to_s] = id if self.class.salesforce_sync_web_id? && !new_record?
       salesforce_id = SF_CLIENT.create!(salesforce_object_name, format_attributes(attributes))
-      if salesforce_id.present? && salesforce_id != 0
-        self.salesforce_id = salesforce_id
-        @exists_in_salesforce = true
-      else
-        raise "Salesforce returned invalid ID: #{salesforce_id}"
-      end
     end
 
     def salesforce_update_object(attributes)

--- a/lib/salesforce_ar_sync/version.rb
+++ b/lib/salesforce_ar_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalesforceArSync
-  VERSION = '5.2.1'
+  VERSION = '5.3.0'
 end

--- a/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
+++ b/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
@@ -521,14 +521,14 @@ describe SalesforceArSync, :vcr do
           }
         )
 
-        expect(SF_CLIENT).to receive(:update).with('Contact', expected_attributes)
+        expect(SF_CLIENT).to receive(:update!).with('Contact', expected_attributes)
         contact.salesforce_update_object(contact.attributes)
       end
     end
 
     context 'when the class should not sync web id' do
       it 'calls SF_CLIENT.update with the correct parameters' do
-        expect(SF_CLIENT).to receive(:update).with('Contact', contact.attributes.merge(Id: contact.salesforce_id))
+        expect(SF_CLIENT).to receive(:update!).with('Contact', contact.attributes.merge(Id: contact.salesforce_id))
         contact.salesforce_update_object(contact.attributes)
       end
     end
@@ -549,14 +549,14 @@ describe SalesforceArSync, :vcr do
       SalesforceArSync.config['SYNC_ENABLED'] = true
       stub_const('SF_CLIENT', restforce_client_stub)
 
-      allow(SF_CLIENT).to receive(:update)
+      allow(SF_CLIENT).to receive(:update!)
       allow(contact).to receive(:salesforce_object_exists?).and_return(true)
     end
 
     context 'when supplied with which attributes to sync' do
       it 'calls SF_CLIENT.update with the correct parameters' do
         contact.salesforce_sync(:first_name, :email_address)
-        expect(SF_CLIENT).to have_received(:update).with(
+        expect(SF_CLIENT).to have_received(:update!).with(
           'Contact',
           Id: contact.salesforce_id,
           Contact.salesforce_sync_attribute_mapping.invert[:first_name] => contact.first_name,
@@ -568,7 +568,7 @@ describe SalesforceArSync, :vcr do
     context 'when supplied with invalid attributes to sync' do
       it 'calls SF_CLIENT.update with the correct parameters' do
         contact.salesforce_sync(:bad_attribute)
-        expect(SF_CLIENT).not_to have_received(:update)
+        expect(SF_CLIENT).not_to have_received(:update!)
       end
     end
   end


### PR DESCRIPTION
salesforce_ar_sync currently uses Restforce CRUD methods that return false when an error occurs when salesforce saves the object.  Change these methods to their bang versions so that we get an error instead of false.